### PR TITLE
Add support for JBIG2 and JPEG images

### DIFF
--- a/handlers/image.py
+++ b/handlers/image.py
@@ -10,6 +10,7 @@ COMMON_IMAGE_EXTENSIONS = {
     "ico", "cur", "ani", "apng", "cur", "ani", "apng",
     "ps", "eps", "ai", "psb", "tif", "tiff", "svgz",
     "dwg", "dxf", "gpx", "kml", "kmz", "3ds", "c4d",
+    "jb2", "jfif", "pjpeg", "pjp", "avif"
 }
 
 


### PR DESCRIPTION
Fixes #6

Add support for more image formats in `handlers/image.py`.

- Add "jb2", "jfif", "pjpeg", "pjp", and "avif" to `COMMON_IMAGE_EXTENSIONS` to support more image suffixes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zmh-program/blob-service/pull/13?shareId=59c6aeb0-8aaa-4d47-bcaa-df9e8b9156bb).